### PR TITLE
feat!: implement restartIfChanged option for containers

### DIFF
--- a/checks/restart-if-changed.nix
+++ b/checks/restart-if-changed.nix
@@ -1,0 +1,39 @@
+{ pkgs, lib, ... }:
+{
+  nodes.host = {
+    virtualisation.nspawn.containers = {
+      backend = {
+        config = {
+          networking.firewall.allowedTCPPorts = [ 80 ];
+          services.nginx = {
+            enable = true;
+            virtualHosts."backend".locations."/".return = lib.mkDefault ''200 "hack the planet"'';
+          };
+        };
+      };
+    };
+
+    specialisation."changed-container".configuration = {
+      virtualisation.nspawn.containers.backend.config.services.nginx.virtualHosts."backend".locations."/".return =
+        ''404 "planet not found"'';
+    };
+  };
+
+  testScript =
+    { nodes, ... }:
+    let
+      specialisations = "${nodes.host.system.build.toplevel}/specialisation";
+    in
+    ''
+      start_all()
+      host.wait_for_unit("systemd-nspawn@backend.service")
+      host.wait_until_succeeds("ping -c 1 backend")
+      host.wait_until_succeeds("${lib.getExe pkgs.curl} -v http://backend | grep 'hack the planet'")
+
+      host.succeed("${specialisations}/changed-container/bin/switch-to-configuration test")
+
+      # Wait until nginx is up again, then make sure we have the *right* response
+      host.wait_until_succeeds("${lib.getExe pkgs.curl} -v http://backend")
+      host.succeed("${lib.getExe pkgs.curl} -v http://backend | grep 'planet not found'")
+    '';
+}


### PR DESCRIPTION
Previously, changing the container's system configuration would not restart or reactivate container on activation. This change implements a simple systemd restart trigger for the templated systemd-nspawn unit.

We also have to change the default value of systemd.nspawn(5) KillSignal= in order to avoid SIGKILL-ing the container on restart and causing potential data loss.

I think we could look into allowing activating new configurations right in the container, to avoid a full restart, but for now this should be good enough.
